### PR TITLE
Handle the case when there is no menu_structure

### DIFF
--- a/djangocms_blog/menu.py
+++ b/djangocms_blog/menu.py
@@ -116,7 +116,11 @@ class BlogNavModifier(Modifier):
         if app and app.app_config:
             namespace = resolve(request.path).namespace
             config = app.get_config(namespace)
-        if config and config.menu_structure != MENU_TYPE_CATEGORIES:
+        try:
+            if config and config.menu_structure != MENU_TYPE_CATEGORIES:
+                return nodes
+        except AttributeError:
+            # config might be not have `menu_structure`
             return nodes
         if post_cut:
             return nodes


### PR DESCRIPTION
```
config = app.get_config(namespace)
```

Might return an instance of another apps config. In that case `menu_structure` is not present and we get HTTP 500
